### PR TITLE
Bmw people missing data

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,7 +34,11 @@ layout: default
             <div class="person-image"><img src="{{ site.baseurl }}/assets/images/{{ page.author }}.jpg" alt="{{ author.name }}"></div>
         {% endif %}
       {% endfor %}
-      <p><a href="{{ site.baseurl }}/people/{{page.author}}/">{{ author.name }}</a>{% if author_categories contains 'Staff' %} is {{ author.position }} in the {{ site.title }}.{% endif %}</p>
+      <p><a href="{{ site.baseurl }}/people/{{page.author}}/">
+        {{ author.name }}</a>{% if author_categories contains 'Staff' %}
+        {% if author.status == 'current' %}is{% else %}was{% endif %}
+        {{ author.position }} in the {{ site.title }}.
+        {% endif %}</p>
 
 <p>Cite this post: {{ author.name }}. "{{ page.title }}". Published {{ page.date | date: "%m/%d/%Y" }}. <a href="{{site.url}}/{{page.url}}">{{site.url}}/{{page.url}}</a>.</p>
     {% endfor %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,7 +34,7 @@ layout: default
             <div class="person-image"><img src="{{ site.baseurl }}/assets/images/{{ page.author }}.jpg" alt="{{ author.name }}"></div>
         {% endif %}
       {% endfor %}
-      <p><a href="{{ site.baseurl }}/people/{{page.author}}/">{{ author.name }}</a> is {{ author.position }}{% if author_categories contains 'Staff' %} in the {{ site.title }}{% endif %}.</p>
+      <p><a href="{{ site.baseurl }}/people/{{page.author}}/">{{ author.name }}</a>{% if author_categories contains 'Staff' %} is {{ author.position }} in the {{ site.title }}.{% endif %}</p>
 
 <p>Cite this post: {{ author.name }}. "{{ page.title }}". Published {{ page.date | date: "%m/%d/%Y" }}. <a href="{{site.url}}/{{page.url}}">{{site.url}}/{{page.url}}</a>.</p>
     {% endfor %}


### PR DESCRIPTION
# Description
We were running into problems with authors who did not have positions in the lab. They were coming up on the post page as 

Dave Richardson is None.

Tweaked the logic so that in the absence of categories it would just sign the post with the person's name instead of a sentence, i.e.:

Dave Richardson

Also noticed that we weren't accounting for whether or not someone was a current / past member of the lab. I.e. - 

Wayne Graham is Head of R&D. 

is outdated, and could lead to people seeking him out in that role if they looked at old posts. So I added logic to give "is/was" depending on whether someone is current staff. 

Let me know if either of those are things that we don't desire? 

## Number of Fixes
2

## Related Ticket(s)
#53 

#### Steps to Test Solution 

1. Can compare different kinds of staff and authors:
http://localhost:4000/2010/01/27/the-1907-massie-map-of-albemarle-co-is-now-in-the-portal/
http://localhost:4000/2010/01/27/the-1907-massie-map-of-albemarle-co-is-now-in-the-portal/