### PR TITLE
Update content for student section

### DIFF
--- a/theme-testing/content-index.html
+++ b/theme-testing/content-index.html
@@ -56,7 +56,7 @@
 		<div class="home__grads">
 			<div class="home-grads__title">Student Opportunities</div>
 			<div class="home-grads__content">
-				<div class="home-grads__subtitle">One of our primary missions is to support the work of emerging scholars and digital humanities practitioners&mdash;particularly UVa graduate students. We offer a variety of fellowships and opportunities to this end, which collectively aim to support students during the full measure of their time at UVA. Whether you're looking to answer a specific call for applications or looking to discuss your research&mdash;we're here to help.</div>
+				<div class="home-grads__subtitle">One of our primary missions is to support the work of emerging scholars and digital humanities practitioners&mdash;particularly UVa graduate students. We offer a variety of fellowships and opportunities to this end, which collectively aim to support graduate students during the full measure of their time at UVA. From the innovative <a href="praxis.scholarslab.org">Praxis Program</a> to professionalization training for students on the DH job market, we're here to help whether you're looking to answer a specific call for applications or simply looking to discuss your research.</div>
 				<div class="home-grads__cta"><a href="#">Student Opportunities Home</a></div>
 			</div>
 		</div>

--- a/theme-testing/content-index.html
+++ b/theme-testing/content-index.html
@@ -54,13 +54,13 @@
 		<!-- Status: bad -->
 		<!-- Issues: need title of page and written content from Brandon. Should be upgraded from "bad" to "fine/good" by Wednesday (2/7). -->
 		<div class="home__grads">
-			<div class="home-grads__title">Opportunities for Graduate Students</div>
+			<div class="home-grads__title">Student Opportunities</div>
 			<div class="home-grads__content">
-				<div class="home-grads__subtitle">One of our primary missions is to support the work of emerging scholars and digital humanities practitioners&mdash;particularly UVa graduate students. Something about variety of opportunities, or whatever Brandon ends up writing. This section explores all the opportunities we offer to graduate students, from our fancy <a href="#">Praxis Program</a> to <a href="#">fellowships</a> I don't know all the names of.</div>
-				<div class="home-grads__cta"><a href="#">Grad Opportunities Home</a></div>
+				<div class="home-grads__subtitle">One of our primary missions is to support the work of emerging scholars and digital humanities practitioners&mdash;particularly UVa graduate students. We offer a variety of fellowships and opportunities to this end, which collectively aim to support students during the full measure of their time at UVA. Whether you're looking to answer a specific call for applications or looking to discuss your research&mdash;we're here to help.</div>
+				<div class="home-grads__cta"><a href="#">Student Opportunities Home</a></div>
 			</div>
 		</div>
-		
+
 		<!-- 5: Office Hours -->
 		<!-- Status: fine -->
 		<!-- Issues: vital information is there, but need a sentence describing the purpose of the office hours. Best solution is to ask Amanda or Laura to literally write down a sentence for me, probably just over Slack. -->
@@ -81,7 +81,7 @@
 				<img src="img/dummy-floor-plan.png" height="300px" alt="Floor diagram of Scholars' Lab spaces" title="By the lovely Beth Mitchell">
 			</div>
 		</div>
-		
+
 		<!-- 7: Makerspace -->
 		<!-- Status: fine -->
 		<!-- Issues: mostly need to ask Shane and Laura to look it over and make changes as they see fit. -->
@@ -105,7 +105,7 @@
 				<div><strong>Who should do this part?</strong>Insert short description, a pic, and event preview, or whatever @Will/Arin/Drew/Chris et al. find useful. GIS, VR/AR, 3-D modeling, other things?</div>
 			</div>
 		</div>
-		
+
 		<!-- 9: Events -->
 		<!-- Status: (potentially) fine -->
 		<!-- Issues: statement likely needs rewording, and need to ask Zoe, Amanda, and/or Laura on how to actually get the events in here. Also: ask Laura about the 3-5 event categories so can get to work on colorizing. Will also need Zoe's help with tagging process at that point. -->
@@ -178,7 +178,7 @@
 			<div class="home-contact2__title">Let's meet up.</div>
 			<div class="home-contact2__content">Come set up a <a href="#">consultation</a> with us. Very casual. Something something if you have a project and wanna fit DH into it, or something something no pressure other reason. <span>Just fill out the form found <a href="#">here</a>.</div>
 		</div>
-		
+
 		<!-- 17: Charter -->
 		<!-- Status: fine -->
 		<!-- Issues: description needs rewording, but otherwise is good. High priority because fix is so easy. Ask Amanda to do ASAP this week. -->


### PR DESCRIPTION
# Description
Add the content for the student section. To your questions Katherine -

I went with "Student Opportunities." Technically, we have at least 2-3 programs listed on that page that are for undergraduates. Tried to make it clear in the description that our primary constituency was graduate students, but open to conversation around this. And I'd been treating the fellowships section as a repository for the different CFP's and descriptions, which I would like to have archived. Will push up a couple tweaks in a second.