### PR TITLE
Starter kit collection set up & configured. Also fixes _config exclude statement issue.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
+  - docs
 collections:
   people:
     output: true

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,9 @@ collections:
   lab:
     output: true
     permalink: /:collection/:name/
+  starter-kits:
+    output: true
+    permalink: /:collection/:name/
 
 header_pages:
   - about.md

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ plugins:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor
 collections:
   people:
     output: true
@@ -43,8 +44,6 @@ header_pages:
   - research.md
   - lab.md
   - search.html
-
-exclude: [vendor]
 
 defaults:
   - scope:

--- a/_layouts/starter-kit.html
+++ b/_layouts/starter-kit.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+<h1>{{ page.title }}</h1>
+{{ content }}

--- a/_starter-kits/networks.md
+++ b/_starter-kits/networks.md
@@ -1,7 +1,7 @@
 ---
 collaborators: ''
 layout: research
-permalink: \networks
+# permalink: \networks
 slug: networks
 title: Networks and Network Analysis
 ---


### PR DESCRIPTION
# Description
1. Fixes issue where starter-kits wouldn't build into local `_site/` folder.
2. Creates skeleton for starter kit layout template.
3. Fixes issue in config that wouldn't allow the 'exclude' statement to take effect. (Plot twist: there was a second exclude statement; these are now combined and working.)

## Number of Fixes
Fixes #74, makes progress on #80