### PR TITLE
Cite this post details added

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -90,8 +90,7 @@ layout: default
 
         <!-- cite post -->
         <div class="post-credits__citation">
-            <span>Cite this post: </span>{{ author.name }}. &ldquo;{{ page.title }}&rdquo;. Published {{ page.date | date: "%m/%d/%Y" }}. <a href="{{site.url}}/{{page.url}}">{{site.url}}/{{page.url}}</a>.
-        </div>
+            <span>Cite this post: </span>{{ author.name }}. &ldquo;{{ page.title }}&rdquo;. Published {{ page.date | date: "%m/%d/%Y" }}. <a href="{{site.url}}/{{page.url}}">{{site.url}}/{{page.url}}</a>. Accessed on {{ "now" | date: "%b %d, %y" }}.        </div>
 
       {% endfor %}
       <!-- END BLOCK -->


### PR DESCRIPTION
Had only added accessed-on info to code for if post had no author—this adds accessed-on info to how to cite this post if it does have an author. For #6 