### PR TITLE
Hours and spaces data structure updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ collections:
   events:
     output: true
     permalink: /:collection/:name/
+  spaces: # output false
 
 header_pages:
   - about.md

--- a/_spaces/classroom.md
+++ b/_spaces/classroom.md
@@ -1,6 +1,7 @@
 ---
 title: The Classroom
 room: Alderman 421
+order: 4
 # hours: (none specified)
 seating: 30
 equipment: "25 Dell laptops; ceiling-mounted data projector; document projector; instructor workstation with desktop, audio, and video."

--- a/_spaces/classroom.md
+++ b/_spaces/classroom.md
@@ -1,0 +1,22 @@
+---
+title: The Classroom
+room: Alderman 421
+# hours: (none specified)
+seating: 30
+equipment: "25 Dell laptops; ceiling-mounted data projector; document projector; instructor workstation with desktop, audio, and video."
+reservations: "This room is typically available only for library-related instruction and activities. Please contact [libevents@virginia.edu](mailto:libevents@virginia.edu) for more information."
+---
+
+The Classroom is a flexible learning space shared by the Scholars' Lab and other library departments, providing space for library-related instruction, workshops, invited speakers, and special events. Scholars' Lab workshops and the speaker series are often held in this room. **When not otherwise reserved, this room is available for use as open study space, with seating for 30 people at chairs and tables. Check the schedule on the door for times when the room is unavailable.**
+
+[![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42101-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42101.jpg) [![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42102-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42102.jpg)
+
+<!--
+ 	
+* **Size:** seating for 30 people
+ 	
+* **Equipment:** 25 Dell laptops; ceiling-mounted data projector; document projector; instructor workstation with desktop, audio, and video.
+ 	
+* **Reservations:** This room is typically available only for library-related instruction and activities. Please contact [libevents@virginia.edu](mailto:libevents@virginia.edu) for more information.
+
+-->

--- a/_spaces/common-room.md
+++ b/_spaces/common-room.md
@@ -1,0 +1,20 @@
+---
+title: The Common Room
+room: Alderman 419
+hours: "The Common Room of the Scholars' Lab is open [whenever Alderman is](http://www.library.virginia.edu/hours/#!/scholars-lab,alderman)."
+seating: 66
+equipment: "12 Dell workstations with [advanced software](http://its.virginia.edu/labs/listEquipDetail.php?room_id=34&machine_group=1) (plus AbbyyFineReader and Adobe Creative Suite); flat bed scanners (2 large format, 4 with multi-sheet feed); color and black and white printers."
+reservations: "Typically not reservable, except for major library or university technology-related events. Contact [scholarslab@virginia.edu](mailto:scholarslab@virginia.edu) for more information."
+---
+
+The Scholars' Lab Common Room provides twenty computer workstations in both solo and small group/collaborative configurations. Sunny and open, it can be enjoyed as study space as well, with additional seating for about thirty-two people at tables and chairs and another fourteen at the laptop bar with a view of the patio outside. Here is where you will also find our [Makerspace](http://www.scholarslab.org/makerspace/).
+
+[![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom001-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom001.jpg) [![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom01-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom01.jpg)
+
+<!--
+  * **Size:** seating for 66
+ 	
+  * **Equipment:** 12 Dell workstations with [advanced software](http://its.virginia.edu/labs/listEquipDetail.php?room_id=34&machine_group=1) (plus AbbyyFineReader and Adobe Creative Suite); flat bed scanners (2 large format, 4 with multi-sheet feed); color and black and white printers.
+ 	
+  * **Reservations:** Typically not reservable, except for major library or university technology-related events. Contact [scholarslab@virginia.edu](mailto:scholarslab@virginia.edu) for more information.
+-->

--- a/_spaces/common-room.md
+++ b/_spaces/common-room.md
@@ -1,6 +1,7 @@
 ---
 title: The Common Room
 room: Alderman 419
+order: 1
 hours: "The Common Room of the Scholars' Lab is open [whenever Alderman is](http://www.library.virginia.edu/hours/#!/scholars-lab,alderman)."
 seating: 66
 equipment: "12 Dell workstations with [advanced software](http://its.virginia.edu/labs/listEquipDetail.php?room_id=34&machine_group=1) (plus AbbyyFineReader and Adobe Creative Suite); flat bed scanners (2 large format, 4 with multi-sheet feed); color and black and white printers."

--- a/_spaces/makerspace.md
+++ b/_spaces/makerspace.md
@@ -1,0 +1,30 @@
+---
+title: Makerspace
+room: Alderman 419
+hours_raw:
+ - Monday: "1:00pm - 7:00pm"
+ - Tuesday: "1:00pm - 7:00pm"
+ - Wednesday: "1:00pm - 7:00pm"
+ - Thursday: "1:00pm - 7:00pm"
+ - Friday: "1:00pm - 5:00pm"
+hours: "1:00pm - 7:00pm, Monday through Thursday and 1:00pm - 5:00pm, Friday, or by appointment"
+seating: 8
+equipment: "Makerbot Replicator 2, Ultimaker 2, Lulzbot Taz 5, [Arduinos](https://www.sparkfun.com/products/12001), and a [variety](http://scholarslab.org/makerspace/) of other maker technologies"
+reservations: "Stop by to talk to one of our student consultants, attend our maker [workshops](http://www.scholarslab.org/events/), or contact us at [scholarslab@virginia.edu](mailto:scholarslab@virginia.edu) to schedule an appointment with Scholars’ Lab staff to discuss your planned project."
+---
+
+The Scholars’ Lab [Makerspace](http://scholarslab.org/makerspace/) is a place for crafting, tinkering, and experimentation with technologies like desktop fabrication, physical computing, and augmented reality. <strong>Open to everyone</strong>&mdash;absolutely no prior experience needed!&mdash;we specialize in hands-on approaches to research questions in the humanities and arts.
+
+[![Partially assembled Sparkfun Inventor's Kit, with an Arduino board, breadboard, and soldering iron](http://scholarslab.org/wp-content/uploads/2014/09/makerspace7-110x110.jpg)](http://scholarslab.org/wp-content/uploads/2014/09/makerspace7.jpg)  [![Makerspace lounge area, with touchscreen and chairs.](http://scholarslab.org/wp-content/uploads/2014/05/makerspace31-110x110.jpg)](http://scholarslab.org/wp-content/uploads/2014/05/makerspace31.jpg)[![The Makerspace printer desk](http://scholarslab.org/wp-content/uploads/2014/05/makerspace4-110x110.jpg)](http://scholarslab.org/wp-content/uploads/2014/05/makerspace4.jpg)
+
+<!--
+
+  * **Hours:** 1:00pm - 7:00pm, Monday through Thursday and 1:00pm - 5:00pm, Friday, or by appointment
+ 	
+  * **Size:** seating for 8
+
+  * **Equipment:** Makerbot Replicator 2, Ultimaker 2, Lulzbot Taz 5, [Arduinos](https://www.sparkfun.com/products/12001), and a [variety](http://scholarslab.org/makerspace/) of other maker technologies
+
+  * **Reservations:**  Stop by to talk to one of our student consultants, attend our maker [workshops](http://www.scholarslab.org/events/), or contact us at [scholarslab@virginia.edu](mailto:scholarslab@virginia.edu) to schedule an appointment with Scholars’ Lab staff to discuss your planned project.
+
+-->

--- a/_spaces/makerspace.md
+++ b/_spaces/makerspace.md
@@ -1,6 +1,7 @@
 ---
 title: Makerspace
 room: Alderman 419
+order: 2
 hours_raw:
  - Monday: "1:00pm - 7:00pm"
  - Tuesday: "1:00pm - 7:00pm"

--- a/_spaces/seminar-room.md
+++ b/_spaces/seminar-room.md
@@ -1,6 +1,7 @@
 ---
 title: The Seminar Room
 room: Alderman 423
+order: 3
 # hours: (none specified)
 seating: 20
 equipment: "ceiling-mounted data projector; instructor station w/audio and video; 2 whiteboards. Note overhead air vents in middle of room mean a mic is required for folks in the back half of the room to hear well."
@@ -9,8 +10,12 @@ reservations: "Throughout most of the year, this room is available for booking b
 
 The Scholars' Lab seminar room is reserved space for library activities instruction, and when not in use as a classroom is available as open study space. Check the schedule on the door for times when the room is unavailable.
 
+<!--
+
 * **Size:** seating for 20
 
 * **Equipment:** ceiling-mounted data projector; instructor station w/audio and video; 2 whiteboards. Note overhead air vents in middle of room mean a mic is required for folks in the back half of the room to hear well.
 
 * **Reservations:** Throughout most of the year, this room is available for booking by members of the UVa community on a first-come first-served basis. Please contact [libevents@virginia.edu](mailto:libevents@virginia.edu) for more information.
+
+-->

--- a/_spaces/seminar-room.md
+++ b/_spaces/seminar-room.md
@@ -1,0 +1,16 @@
+---
+title: The Seminar Room
+room: Alderman 423
+# hours: (none specified)
+seating: 20
+equipment: "ceiling-mounted data projector; instructor station w/audio and video; 2 whiteboards. Note overhead air vents in middle of room mean a mic is required for folks in the back half of the room to hear well."
+reservations: "Throughout most of the year, this room is available for booking by members of the UVa community on a first-come first-served basis. Please contact [libevents@virginia.edu](mailto:libevents@virginia.edu) for more information."
+---
+
+The Scholars' Lab seminar room is reserved space for library activities instruction, and when not in use as a classroom is available as open study space. Check the schedule on the door for times when the room is unavailable.
+
+* **Size:** seating for 20
+
+* **Equipment:** ceiling-mounted data projector; instructor station w/audio and video; 2 whiteboards. Note overhead air vents in middle of room mean a mic is required for folks in the back half of the room to hear well.
+
+* **Reservations:** Throughout most of the year, this room is available for booking by members of the UVa community on a first-come first-served basis. Please contact [libevents@virginia.edu](mailto:libevents@virginia.edu) for more information.

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@ title: Home
 					<li>Staff offices</li>
 				</ul>
 			</div>
+			<p class="home-find__link">See full list of <a href="/hours-and-spaces" aria-label="hours and spaces page">hours &amp; spaces</a>.</p>
 		</section>
 
 		<!-- events: -->

--- a/index.html
+++ b/index.html
@@ -101,9 +101,12 @@ title: Home
 					<img src="{{ 'assets/img/svg/alderman-floorplan.svg' | relative_url }}" height="300px" alt="Floor diagram of Scholars' Lab spaces" title="Alderman Floorplan - Floor 4">
 				</div>
 				<ul><span>Spaces:</span>
-					<li>Space #1: Alderman 419</li>
-					<li>Lorem ipsum</li>
-					<li>Dolor: sic amet 418</li>
+					{% assign spaces = site.spaces | sort: 'order' %}
+					{% for space in spaces %}
+					<li>{{ space.title }}: {{ space.room }}</li>
+					{% endfor %}
+					<li>Open Office Hours</li>
+					<li>Staff offices</li>
 				</ul>
 		</section>
 

--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@ title: Home
 					<li>Open Office Hours</li>
 					<li>Staff offices</li>
 				</ul>
+			</div>
 		</section>
 
 		<!-- events: -->

--- a/pages/hours-and-spaces.md
+++ b/pages/hours-and-spaces.md
@@ -12,94 +12,24 @@ notes:
 
 The Common Room of the Scholars' Lab is open [whenever Alderman is](http://www.library.virginia.edu/hours/#!/scholars-lab,alderman), and during the semester our central [Makerspace](http://www.scholarslab.org/makerspace/) is staffed from **1:00 pm - 7:00 pm, Monday through Thursday and 1:00 pm - 5:00 pm, Friday**. Visit the Common Room, Seminar Room (Alderman 423), and Classroom (Alderman 421)! Scholars' Lab [staff](http://scholarslab.org/people) offices are nearby, where [our grad fellows](http://www.scholarslab.org/graduate-fellowships/) also have access to a workspace and office.
 
+{% assign spaces = site.spaces | sort: 'order' %}
+{% for space in spaces %}
+## {{ space.title }}
 
-## The Common Room
+_{{ space.room }}_
 
+{{ space.content }}
 
-_Alderman 419_
-
-The Scholars' Lab Common Room provides twenty computer workstations in both solo and small group/collaborative configurations. Sunny and open, it can be enjoyed as study space as well, with additional seating for about thirty-two people at tables and chairs and another fourteen at the laptop bar with a view of the patio outside. Here is where you will also find our [Makerspace](http://www.scholarslab.org/makerspace/).
-
-[![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom001-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom001.jpg) [![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom01-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabcommonroom01.jpg)
-
-
-
- 	
-  * **Size:** seating for 66
-
- 	
-  * **Equipment:** 12 Dell workstations with [advanced software](http://its.virginia.edu/labs/listEquipDetail.php?room_id=34&machine_group=1) (plus AbbyyFineReader and Adobe Creative Suite); flat bed scanners (2 large format, 4 with multi-sheet feed); color and black and white printers.
-
- 	
-  * **Reservations:** Typically not reservable, except for major library or university technology-related events. Contact [scholarslab@virginia.edu](mailto:scholarslab@virginia.edu) for more information.
-
-
-
-
-## The Makerspace
-
-
-The Scholars’ Lab [Makerspace](http://scholarslab.org/makerspace/) is a place for crafting, tinkering, and experimentation with technologies like desktop fabrication, physical computing, and augmented reality. <strong>Open to everyone</strong>&mdash;absolutely no prior experience needed!&mdash;we specialize in hands-on approaches to research questions in the humanities and arts.
-
-[![Partially assembled Sparkfun Inventor's Kit, with an Arduino board, breadboard, and soldering iron](http://scholarslab.org/wp-content/uploads/2014/09/makerspace7-110x110.jpg)](http://scholarslab.org/wp-content/uploads/2014/09/makerspace7.jpg)  [![Makerspace lounge area, with touchscreen and chairs.](http://scholarslab.org/wp-content/uploads/2014/05/makerspace31-110x110.jpg)](http://scholarslab.org/wp-content/uploads/2014/05/makerspace31.jpg)[![The Makerspace printer desk](http://scholarslab.org/wp-content/uploads/2014/05/makerspace4-110x110.jpg)](http://scholarslab.org/wp-content/uploads/2014/05/makerspace4.jpg)
-
-
-
- 	
-  * **Hours:** 1:00 pm - 7:00 pm, Monday through Thursday and 1:00 pm - 5:00 pm, Friday, or by appointment
-
- 	
-  * **Size:** seating for 8
-
- 	
-  * **Equipment:** Makerbot Replicator 2, Ultimaker 2, Lulzbot Taz 5, [Arduinos](https://www.sparkfun.com/products/12001), and a [variety](http://scholarslab.org/makerspace/) of other maker technologies
-
- 	
-  * **Reservations:**  Stop by to talk to one of our student consultants, attend our maker [workshops](http://www.scholarslab.org/events/), or contact us at [scholarslab@virginia.edu](mailto:scholarslab@virginia.edu) to schedule an appointment with Scholars’ Lab staff to discuss your planned project.
-
-
-
-
-
-## The Seminar Room
-
-
-_Alderman 423_
-
-The Scholars' Lab seminar room is reserved space for library activities instruction, and when not in use as a classroom is available as open study space. Check the schedule on the door for times when the room is unavailable.
-
-
-
- 	
-  * **Size:** seating for 20
-
- 	
-  * **Equipment:** ceiling-mounted data projector; instructor station w/audio and video; 2 whiteboards. Note overhead air vents in middle of room mean a mic is required for folks in the back half of the room to hear well.
-
- 	
-  * **Reservations:** Throughout most of the year, this room is available for booking by members of the UVa community on a first-come first-served basis. Please contact [libevents@virginia.edu](mailto:libevents@virginia.edu) for more information.
-
-
-
-
-## The Classroom
-
-
-_Alderman 421_
-
-The Classroom is a flexible learning space shared by the Scholars' Lab and other library departments, providing space for library-related instruction, workshops, invited speakers, and special events. Scholars' Lab workshops and the speaker series are often held in this room. **When not otherwise reserved, this room is available for use as open study space, with seating for 30 people at chairs and tables. Check the schedule on the door for times when the room is unavailable.**
-
-[![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42101-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42101.jpg) [![](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42102-110x110.jpg)](http://www.scholarslab.org/wp-content/uploads/2012/10/slabalderman42102.jpg)
-
-
-
- 	
-  * **Size:** seating for 30 people
-
- 	
-  * **Equipment:** 25 Dell laptops; ceiling-mounted data projector; document projector; instructor workstation with desktop, audio, and video.
-
- 	
-  * **Reservations:** This room is typically available only for library-related instruction and activities. Please contact [libevents@virginia.edu](mailto:libevents@virginia.edu) for more information.
-
-
+{% if space.hours %}
+  - **Hours:** {{ space.hours }}
+{% endif %}
+{% if space.seating %}
+  - **Size:** seating for {{ space.seating }}
+{% endif %}
+{% if space.equipment %}
+  - **Equipment:** {{ space.equipment }}
+{% endif %}
+{% if space.reservations %}
+  - **Reservations:** {{ space.reservations }}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
# Description
- Add a collection for "spaces" and register a file for each space that already existed in the Hours & Spaces page
  - Common Area, Seminar Room, Classroom, Makerspace
- Use that data structure to loop through the places listed on 'Find Us' section of homepage
  - Append w/ couple things we haven't listed yet
- Use YAML vars to organize data structure that had been strings in the content of Hours & Spaces:

```yaml
# location: ./_spaces/makerspace.md

title: Makerspace
room: Alderman 419
order: 2
hours_raw:
 - Monday: "1:00pm - 7:00pm"
 - Tuesday: "1:00pm - 7:00pm"
 - Wednesday: "1:00pm - 7:00pm"
 - Thursday: "1:00pm - 7:00pm"
 - Friday: "1:00pm - 5:00pm"
hours: "1:00pm - 7:00pm, Monday through Thursday and 1:00pm - 5:00pm, Friday, or by appointment"
seating: 8
equipment: "Makerbot Replicator 2, Ultimaker 2, Lulzbot Taz 5, [Arduinos](https://www.sparkfun.com/products/12001), and a [variety](http://scholarslab.org/makerspace/) of other maker technologies"
reservations: "Stop by to talk to one of our student consultants, attend our maker [workshops](http://www.scholarslab.org/events/), or contact us at [scholarslab@virginia.edu](mailto:scholarslab@virginia.edu) to schedule an appointment with Scholars’ Lab staff to discuss your planned project."
```
- NB: `hours_raw` only exists for Makerspace (only one w/ individual hours), and data structured as strings right now might best take a different form - people are welcome to edit as see fit. Just copied what we already had for size, reservations, etc., and put into YAML front matter.
  - Order = display order, so the display was unchanged from before I messed w/ the data structure.

## Closing an issue? Hurray!
- Closes #312 

## Related Ticket(s)
- Partly addresses #222 & #311