### PR TITLE
Skip initial build for serving when also testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ task :test_travis do
   }
   
   HTMLProofer.check_directory("./_site", options).run
-  sh 'bundle exec jekyll serve --incremental'
+  sh 'bundle exec jekyll serve --incremental --skip-initial-build'
 end
 
 desc "Make a research project"


### PR DESCRIPTION
Closes #440 

As mentioned on the issue - it looked like this was discussed on slack but never implemented. Now if we could only figure out why it is repaginating the entire blog every time it incrementally regenerates……