### PR TITLE
Only load search javascripts on search page.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,12 +13,14 @@
 
 		{% include footer.html %}
 
-		<script src="https://unpkg.com/lunr/lunr.js" type="text/javascript" charset="utf-8"></script>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.19.1/moment.min.js" type="text/javascript" charset="utf-8"></script>
 		<script src="{{ '/assets/js/lib/hammer.min.js' | relative_url }}" type="text/javascript" charset="utf-8"></script>
 		<script src="{{ '/assets/js/main.js' | relative_url }}" type="text/javascript" charset="utf-8"></script>
+        {% if page.title == 'Search' %}
+		<script src="https://unpkg.com/lunr/lunr.js" type="text/javascript" charset="utf-8"></script>
 		<script src="{{ '/assets/js/search.js' | relative_url }}" type="text/javascript" charset="utf-8"></script>
+        {% endif %}
 
 	</body>
 


### PR DESCRIPTION
Adds a conditional to check if the page title is 'Search' before
including javascript assets for search.

Fixes #420.
