### PR TITLE
Rake the forests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,3 @@
-sh 'gem install bundler'
-sh 'bundle install'
-
 require 'date'
 require 'time'
 require 'html-proofer'
@@ -19,6 +16,7 @@ end
 
 desc "Install dependencies"
 task :install_dependencies do
+    sh 'bundle install'
     sh 'npm install'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -40,6 +40,11 @@ task :test_build do
   sh 'bundle exec jekyll serve --incremental --skip-initial-build'
 end
 
+desc "Build the site."
+task :build_site do
+    sh 'bundle exec jekyll build'
+end
+
 desc "Make a research project"
 task :new_project, [:title] do |t, args|
   title_slug = args.title.downcase.gsub(' ', '-')
@@ -195,3 +200,4 @@ file './search_index.json' => ['./corpus.json'] do |t|
 end
 
 task :default => [:install_dependencies, :delete_corpus, './corpus.json', './search_index.json', :test_build]
+task :publish => [:install_dependencies, :delete_corpus, './corpus.json', './search_index.json', :build_site]

--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,8 @@ task :install_dependencies do
     sh 'npm install'
 end
 
-desc "Run travis tests"
-task :test_travis do
+desc "Run tests on the build."
+task :test_build do
     sh 'bundle exec jekyll build'
     options = {
       :assume_extension => true,
@@ -194,4 +194,4 @@ file './search_index.json' => ['./corpus.json'] do |t|
   end
 end
 
-task :default => [:install_dependencies, :delete_corpus, './corpus.json', './search_index.json', :test_travis]
+task :default => [:install_dependencies, :delete_corpus, './corpus.json', './search_index.json', :test_build]


### PR DESCRIPTION
Updates our Rake tasks, to the following:

- Removes sh command to install bundler (we already require it);
- Moves `bundle install` to the install dependencies task;
- Removes the progress bar;
- Creates a new task `publish`, for deployment to the server, that
  1. installs dependencies;
  2. builds search files;
  3. builds the site to `_site`