### PR TITLE
Closes #571

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,8 @@
         <a href="#main" aria-label="Back to top">
           <img src="{{ '/assets/img/svg/thin-up-arrow-white.svg' | relative_url }}" alt="Up arrow">
           <span>Back<br/>to top</span>
-        </a>
+        </a><br><br>
+        <a href="https://github.com/scholarslab/scholarslab.org/blob/master/docs/authoring-and-editing.md">How to blog</a>
     </div>
 
     <div class="footer__sitemap">


### PR DESCRIPTION
Adds link to blogging docs in footer of site, under "back to top" link. Checked in multiple mobile window sizes.