### PR TITLE
Supports multiple authors for posts. Fixes #563.

### DIFF
--- a/_includes/author-name.html
+++ b/_includes/author-name.html
@@ -1,0 +1,19 @@
+{% capture authorstring %}
+{% assign authors = include.authorid %}
+{% if authors.size > 0 %}
+{% for author in authors %}
+  {% assign people = site.people | where: 'slug', author %}
+  {% if people.size > 0 %}
+  {% for person in people %}
+  <a href="{{ site.baseurl }}/people/{{ person.slug }}/">{{ person.title }}</a>,
+  {% endfor %}
+  {% else %}
+  {{ author }},
+  {% endif %}
+{% endfor %}
+{% else %}
+Scholars’ Lab
+{% endif %}
+{% endcapture %}
+{% assign authorarray =  authorstring | strip | split: "," %}
+{{ authorarray | array_to_sentence_string }}

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,0 +1,31 @@
+{% assign authors = site.people | where: 'slug', include.authorid %}
+{% assign profile_image = '/assets/img/people/cropped/scholarslab.png' %}
+
+{% if authors != nil %}
+{% for author in authors %}
+          {% assign images = site.static_files | limit: 1 | where: 'basename', author.slug | where_exp:"image","image.path contains 'cropped'" %}
+          {% if images %}
+          {% for image in images %}
+          {% assign profile_image = image.path %}
+          {% endfor %}
+          {% endif %}
+
+        <div class="post-credits__author">
+
+          <div class="post-author__image">
+              <img src="{{ profile_image }} " alt="">
+          </div>
+          <!-- link to author's person page -->
+          <div class="post-author__name">
+            <a href="{{ author.url | relative_url }}">{{ author.title }}</a>
+            <!-- list position if relevant: -->
+            {% if author.position %}
+              {% if author.status == 'current' %}is{% else %}was{% endif %}
+                {{ author.position }} in the {{ site.title }}.
+            {% endif %}
+          </div>
+        </div>
+
+{% endfor %}
+{% else %}
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,8 +1,7 @@
 ---
 layout: default
 ---
-
-{% assign authors = site.people | where: "slug", page.author %}
+{% capture authorstring %}{% include author-name.html authorid=page.author %}{% endcapture %}
 
 <article class="post-wrapper">
 
@@ -19,18 +18,7 @@ layout: default
       {% endif %}
 
       <div class="post-meta__author">
-        <span>By</span>
-        {% for author in authors %}
-            <a href="{{ site.baseurl }}/people/{{page.author}}/">{{ author.title }}</a>
-        {% endfor %}
-        {% if authors == empty %}
-            {% assign author = page.author | split: '-' %}
-                {% for name in author %}
-                    {{ name | capitalize}}
-                {% endfor %}
-        {% endif %}
-        <!-- date: -->
-        on <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+        <span>By</span> {{ authorstring | strip }} on <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
       </div>
 
       {% assign catsize = page.categories | size %}
@@ -65,41 +53,14 @@ layout: default
     </div>
 
     <footer class="post__credits">
-      <!-- START BLOCK -->
-      {% for author in authors %} <!-- if there is a listed author -->
-        {% assign author_categories = author.people-category | join: "," %}
-
-        <div class="post-credits__author">
-          <!-- display person pic if exists. break statement means the loop will end once the if statement runs once.  -->
-          {{ profile_pic }}
-          {% for image in site.static_files %}
-            {% if image.basename == page.author and image.path contains 'cropped' %}
-                <div class="post-author__image">
-                  <img src="{{ site.baseurl }}/assets/img/people/cropped/{{ page.author }}.jpg" alt="{{ author.title }}">
-                </div>
-            {% break %}
-            {% endif %}
-          {% endfor %}
-          {% assign image_array_size = site.static_files | where: "basename", page.author | size %}
-          {% if image_array_size == 0 %}
-          <div class="post-author__image">
-            <img src="{{ site.baseurl }}/assets/img/people/cropped/scholarslab.png" alt="Scholars' Lab Lab">
-          </div>
-          {% endif %}
-          <!-- link to author's person page -->
-          <div class="post-author__name">
-            <a href="{{ site.baseurl }}/people/{{page.author}}/">{{ author.title }}</a>
-            <!-- list position if relevant: -->
-            {% if author_categories contains 'Staff' %}
-              {% if author.status == 'current' %}is{% else %}was{% endif %}
-                {{ author.position }} in the {{ site.title }}.
-            {% endif %}
-          </div>
-        </div>
-
+      {% comment %}
+      {% for author in page.author %} <!-- if there is a listed author -->
+      {% include author-profile.html authorid=page.author %}
+      {% endfor %}
+      {% endcomment %}
         <!-- cite post -->
         <div class="post-credits__citation">
-            <span>Cite this post: </span>{{ author.title }}. &ldquo;{{ page.title }}&rdquo;. Published {{ page.date | date: "%B %d, %Y" }}. <a href="{{site.url}}/{{page.url}}">{{site.url}}/{{page.url}}</a>. Accessed on 
+            <span>Cite this post: </span>{{ authorstring | strip }}. &ldquo;{{ page.title }}&rdquo;. Published {{ page.date | date: "%B %d, %Y" }}. <a href="{{site.url}}/{{page.url}}">{{site.url}}/{{page.url}}</a>. Accessed on 
 <script>
 <!-- 
 var now = new Date();
@@ -115,41 +76,6 @@ document.write(today);
 -->
 </script>.
         </div>
-      {% endfor %}
-      <!-- END BLOCK -->
-
-      <!-- START ALTERNATE BLOCK -->
-      {% if authors == empty %} <!-- if there is no listed author -->
-      <div class="post-credits__author">
-        <div class="post-author__image">
-          <img src="{{ site.baseurl }}/assets/img/people/cropped/scholarslab.png" alt="Scholars' Lab Lab">
-        </div>
-        <!-- link to author's person page -->
-        <div class="post-author__name">
-          <div id="anonymous">Admin</div>
-        </div>
-      </div>
-        <div class="post-credits__citation">
-          <span>Cite this post: </span>
-		  <p>Scholars' Lab Blog. &ldquo;{{ page.title }}&rdquo;. Published {{ page.date | date: "%B %d, %Y" }}. <a href="{{site.url}}/{{page.url}}">{{site.url}}/{{page.url}}</a>. Accessed on
-<script>
-<!-- 
-var now = new Date();
-var months = new Array('January','February','March','April','May','June','July','August','September','October','November','December');
-var date = ((now.getDate()<10) ? "0" : "")+ now.getDate();
-function fourdigits(number) {
-    return (number < 1000) ? number + 1900 : number;
-}
-today =  months[now.getMonth()] + " " +
-         date + ", " +
-         (fourdigits(now.getYear())) ;
-document.write(today);
--->
-</script>.
-          </p>
-        </div>
-      {% endif %}
-      <!-- END BLOCK -->
 
     </footer> <!-- end post footer -->
   </div> <!-- end post-main-content -->

--- a/collections/_posts/2018-09-27-i-o-reading-writing-as-a-digital-humanist.md
+++ b/collections/_posts/2018-09-27-i-o-reading-writing-as-a-digital-humanist.md
@@ -1,5 +1,8 @@
 ---
-author: amanda-visconti
+author:
+ - amanda-visconti
+ - ammon-shepherd
+ - brandon-walsh
 date: 2018-09-27 11:58:06+00:00
 layout: post
 slug: i-o-reading-writing-as-a-digital-humanist

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -17,6 +17,9 @@ order: 2
 		<div class="blog-gallery">
 			<!-- post layout: -->
 			{% for post in site.posts limit:4 %}
+            {% capture authorstring %}
+            {% include author-name.html authorid=post.author %}
+            {% endcapture %}
 			<section class="blog-gallery__item">
 				<div class="blog-item__title">
 					<span>
@@ -60,19 +63,9 @@ order: 2
 				<div class="blog-item__quote">{{ post.content | truncatewords: 25 | markdownify | strip_html }}</div>
 				{% endif %}
 				<div class="blog-item__metadata">
-					<!-- fetch author object, link to their page -->
-					{% assign author_object = site.people | where: 'slug', post.author %}
 					<div class="blog-meta__author">
-						{% for author in author_object %}
-						    <a href="{{ site.baseurl }}/people/{{post.author}}/">{{ author.title }}</a>
-						{% endfor %}
-						{% if author_object == empty %}
-						    {% assign author = post.author | split: '-' %}
-						        {% for name in author %}
-						            {{ name | capitalize}}
-						        {% endfor %}
-						{% endif %}
-					</div>
+                    {{ authorstring | strip }}
+                    </div>
 					<span>&#124;</span> <!-- pipe -->
 					<div class="blog-meta__date">
 						<span class="blog-date__small">{{ post.date | date: "%m.%d.%Y" }}</span>
@@ -86,7 +79,9 @@ order: 2
 <h2>Previous Posts</h2>
 <ul class="page-previous_posts">
 {% for post in site.posts offset:4 %}
-
+{% capture authorstring %}
+{% include author-name.html authorid=post.author %}
+{% endcapture %}
   {% assign currentdate = post.date | date: "%Y" %}
   {% if currentdate != date %}
     {% unless forloop.first %}</ul>{% endunless %}
@@ -94,9 +89,7 @@ order: 2
     <ul>
     {% assign date = currentdate %}
   {% endif %}
-  
-    <li><a href="{{ post.url }}">"{{ post.title }}"</a> by {% assign author_object = site.people | where: 'slug', post.author %}{% for author in author_object %}<a href="{{ site.baseurl }}/people/{{post.author}}/">{{ author.title }}</a>
-{% endfor %}</li>
+    <li><a href="{{ post.url }}">"{{ post.title }}"</a> by {{ authorstring | strip }}</li>
   {% if forloop.last %}</ul>{% endif %}
 
 {% endfor %}


### PR DESCRIPTION
- Updates the logic for querying for post author information, with
preference for using data in the person record instead of splitting and
capitalizing the post author string;
- Adds two partials for displaying author information: One for their
linked name, the ohter for name and appropriate biographical
information. The latter is currently commented out in the post layout
until we can reliably display info for our authors.
- Updates blog post to reflect multiple authors.