### PR TITLE
Drew branch

### DIFF
--- a/pages/spatial-technologies.html
+++ b/pages/spatial-technologies.html
@@ -86,7 +86,7 @@ order: 6
 		<div class="spatial-faq__title">Resources</div>
 		<ul class="spatial-faq__list">
 			<ul class="spatial-starting__gis">
-			<li><span>University support of GIS:</span> <a href="https://guides.lib.virginia.edu/c.php?g=514920&p=3520109">GIS Lib Guide</a></li>
+			<li><span>University support of GIS:</span> <a href="https://guides.lib.virginia.edu/gis">GIS Lib Guide</a></li>
 			<li><span>Cultural heritage informatics at UVA:</span> <a href="https://pages.shanti.virginia.edu/Cultural_Heritage_Data/">data, demos, and news</a></li>
 			</ul>
 		</ul>
@@ -99,19 +99,19 @@ order: 6
 		<div class="maker-inventory__list">
 		  <!-- 3D Printing -->
 		  <ul class="maker-list__3d">
-		    <span>GIS software & extensions</span>
-		    <li><a href="https://guides.lib.virginia.edu/gis/ArcGIS_Installation">ArcMap</a></li>
+			  <span><a href="https://guides.lib.virginia.edu/gis/software">GIS software & extensions</a></span>
+		    <li>ArcMap</li>
 		    <li>ArcGIS Pro</li>
 		    <li>ArcGIS Server</li>
 		    <li>Drone2Map</li>
 			<li>City Engine*</li>
-		    <li><a href="https://guides.lib.virginia.edu/gis/businessAnalyst">Business Analyst</a></li>
+		    <li><a href="https://guides.lib.virginia.edu/gis/data#s-lib-ctab-20595222-4">Business Analyst</a></li>
 		    <li>Network Analyst</li>
 		    <li>Spatial Analyst</li>
 		  </ul>
 		  <!-- VR/AR/3D -->
 		  <ul class="maker-list__vr-ar">
-		    <span><a href="https://guides.lib.virginia.edu/c.php?g=514920&p=5784715">ArcGIS Online Enterprise Access</a></span>
+		    <span><a href="https://guides.lib.virginia.edu/gis/software#s-lib-ctab-20595149-3">ArcGIS Online Enterprise Access</a></span>
             <li>Story maps</li>
             <li>Web AppBuilder</li>
             <li>Business Analyst Online</li>
@@ -125,9 +125,9 @@ order: 6
 		  </ul>
 		  <!-- Textiles, Wearables - Learn how to take fashion into the future. -->
 		  <ul class="maker-list__wearables">
-		    <span>GIS data</span>
-		    <li><a href="https://guides.lib.virginia.edu/gis/sharedDrive">Shared Drive</a></li>
-		    <li><a href="http://data-uvalibrary.opendata.arcgis.com/">Open Data Portal</a></li>
+			  <span><a href="https://guides.lib.virginia.edu/gis/data">GIS data</a></span>
+		    <li>Shared Drive</li>
+		    <li>Open Data Portal</li>
 		  </ul>
 		  <!-- Textiles, Wearables - Learn how to take fashion into the future. -->
 		  <ul class="maker-list__wearables">

--- a/pages/spatial-technologies.html
+++ b/pages/spatial-technologies.html
@@ -127,7 +127,7 @@ order: 6
 		  <ul class="maker-list__wearables">
 			  <span><a href="https://guides.lib.virginia.edu/gis/data">GIS data</a></span>
 		    <li>Shared Drive</li>
-		    <li>Open Data Portal</li>
+		    <li><a href="http://data-uvalibrary.opendata.arcgis.com/">Open Data Portal</a></li>
 		  </ul>
 		  <!-- Textiles, Wearables - Learn how to take fashion into the future. -->
 		  <ul class="maker-list__wearables">


### PR DESCRIPTION
Updated broken LibGuide links. 

FYI, I don't see "scholarslab/reviewers" in the Reviewers list, per the documentation. Sorry to spam those that I shouldn't be spamming.

# Description
Broken Links. Chris created a new GIS LibGuide, and eliminated the old one, breaking the links on this page. I changed some of the linked text as well. The format of our LibGuide has changed, so I moved some of the links from the list text to the headers. If you would prefer, I'm happy to send the links to the appropriate person to fix, rather than doing it myself. I was feeling empowered after reading the excellent GitHub tutorial.

----
(OPTIONAL)
#### Problem to Solve 
Broken links

#### Expected Behavior 
Working links

#### Steps to Test Solution 
1. Copy/Pasted code to static HTML file to test links. Links work but cannot verify formatting with this method.




