### PR TITLE
Replace Scholar Dog default w/3D printing image

### DIFF
--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -48,7 +48,7 @@ layout: default
 		{% endif %}
 		<div class="person__img">
 			{% if profile_pic == empty %}
-			    <img src="{{ site.baseurl }}/assets/img/people/scholarslab.png" alt="Scholars' Lab Lab">
+			    <img src="{{ site.baseurl }}/assets/img/people/grid/default-printing.jpg" alt="[Default image] Makerspace printing in process">
 			{% else %}
 			    {% for pic in profile_pic %}
 			    {% unless pic.path contains 'cropped'  or pic.path contains 'grid' %}

--- a/pages/people.html
+++ b/pages/people.html
@@ -34,7 +34,7 @@ nav: true
           <a href="/people/{{ person.slug }}/" aria-label="{{ person.title }}">
             <div class="people-item__img">
             {% if profile_pic == empty %}
-              <img src="{{ site.baseurl }}/assets/img/people/grid/scholarslab.png" alt="Scholars' Lab Lab">
+              <img src="{{ site.baseurl }}/assets/img/people/grid/default-printing.jpg" alt="[Default image] Makerspace printing in process">
             {% else %}
               {% for pic in profile_pic %}
               {% if pic.path contains 'grid' %}


### PR DESCRIPTION
for #694 

/people uses a variety of Makerspace photos as defaults when a person doesn't have a photo, but on individual people pages the Scholars' Lab Dog photo was still appearing for folks w/o photos; this replaces the dog with the 3D printing photo